### PR TITLE
Small changes to use the role from CentOS

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,3 +17,5 @@ fluentd_service_enabled: yes # yes, no
 # Templates path
 fluentd_playbook_templates_path: "{{ playbook_dir }}/templates/fluentd"
 fluentd_service_template_path: fluentd/fluentd.service.j2
+
+fluentd_required_libs: ["ruby", "ruby-dev"]

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -11,7 +11,7 @@
     group: "{{ fluentd_group }}"
 
 - name: FLUENTD | Install required libs
-  apt:
+  package:
     name: "{{ item }}"
     update_cache: yes
   with_items: "{{ fluentd_required_libs }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,1 @@
 ---
-fluentd_required_libs: ["ruby", "ruby-dev"]


### PR DESCRIPTION

### Description of the Change

In order to override package names, I moved the package definition array out of vars/main.yml and into defaults/main.yml. This will make it possible for me to override whats defined in the array. I need to override it when using the role in CentOS since package "ruby-dev" is named "ruby-devel".


### Benefits

Better support for other OS:es than Ubuntu

### Possible Drawbacks

None i know about

### Applicable Issues

Use the role in CentOS